### PR TITLE
How to run this project

### DIFF
--- a/chirp-backend/node-api/package.json
+++ b/chirp-backend/node-api/package.json
@@ -43,7 +43,7 @@
     "swagger-ui-express": "^5.0.0",
     "swagger-jsdoc": "^6.2.8",
     "uuid": "^9.0.1",
-    "@azure/cognitiveservices-speech-sdk": "^1.33.1",
+    "microsoft-cognitiveservices-speech-sdk": "^1.33.1",
     "elevenlabs-node": "^1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Correct Azure Speech SDK package name to fix `npm install` failures.

The previous package name `@azure/cognitiveservices-speech-sdk` was incorrect, causing `npm install` to fail with an E404 error. The correct package name is `microsoft-cognitiveservices-speech-sdk`, which resolves the issue and allows backend dependencies to install successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fab8bf1-1130-474c-b794-062bdca35257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fab8bf1-1130-474c-b794-062bdca35257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

